### PR TITLE
🐛 Punctuation Whitespace

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "typographizer-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "typographizer-js",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "A script to fix typographic errors",
   "main": "dist/index.umd.js",
   "scripts": {

--- a/source/index.js
+++ b/source/index.js
@@ -81,12 +81,16 @@ export default class TypographizerJS {
   /**
    * Trim whitespace
    *
+   * Regexr example: https://regexr.com/4he5a
+   *
    * @param {*} str
    * @returns
    * @memberof TypographizerJS
    */
   async fixAiryPunctuation (str) {
-    const airy = /( )[.,;?!]{1}(?= +)/gimu
+    if (this.language.code === 'fr') return str
+
+    const airy = /( )[.,;?!]{1}(?= *)/gimu
 
     return str.replace(airy, (found) => found.trim())
   }

--- a/test/__samples__/punctuation.js
+++ b/test/__samples__/punctuation.js
@@ -1,1 +1,1 @@
-export const airyPunctuation = `I know that many people were taught to put two spaces between sentences . I was too. But these days , using two spaces is an obsolete habit . Some say the habit originated in the typewriter era.`
+export const airyPunctuation = `I know that many people were taught to put two spaces between sentences . I was too. But these days , using two spaces is an obsolete habit . Some say the habit originated in the typewriter era. Oh ; by the way, what time is it ?`

--- a/test/languages/french.spec.js
+++ b/test/languages/french.spec.js
@@ -1,0 +1,14 @@
+import test from 'ava'
+import TypographizerJS from '../../source'
+
+let Typographizer
+
+test.beforeEach(() => {
+  Typographizer = new TypographizerJS('fr')
+})
+
+test('preserves white space around punctuation', async (t) => {
+  const formatted = await Typographizer.typographize('Je t’aime ; m’aimes-tu ?')
+
+  t.is(formatted, 'Je t’aime ; m’aimes-tu ?')
+})

--- a/test/languages/localization.spec.js
+++ b/test/languages/localization.spec.js
@@ -1,6 +1,6 @@
 import test from 'ava'
-import TypographizerJS from '../source'
-import quotesets from '../source/data/quotesets'
+import TypographizerJS from '../../source'
+import quotesets from '../../source/data/quotesets'
 
 test('set english quotes as default', (t) => {
   const Typographizer = new TypographizerJS()

--- a/test/punctuation.spec.js
+++ b/test/punctuation.spec.js
@@ -12,5 +12,5 @@ test.beforeEach(async (t) => {
 })
 
 test('Remove spaces in front of punctuation', (t) => {
-  t.is(replaced, 'I know that many people were taught to put two spaces between sentences. I was too. But these days, using two spaces is an obsolete habit. Some say the habit originated in the typewriter era.')
+  t.is(replaced, 'I know that many people were taught to put two spaces between sentences. I was too. But these days, using two spaces is an obsolete habit. Some say the habit originated in the typewriter era. Oh; by the way, what time is it?')
 })


### PR DESCRIPTION
- Don’t remove whitespace around punctuation in French
- Fix RegEx to remove whitespace in front of punctuation at the end of a string